### PR TITLE
Fix uncorrect provider specification

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,3 @@
-provider "aws" {}
-
 resource "aws_iam_role" "iterator" {
   name               = "hfl-iterator"
   assume_role_policy = file("${path.module}/assume_role_policy.json")

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "4.65.0"
+    }
+  }
+  required_version = "~> 1.3"
+}


### PR DESCRIPTION
## Summary

Using

```
provider aws {}
```

Is forcing how the provider should be used, it should not be in the
module but in the folder using this module

## Test plan

Used it somewhere else and did `terraform init`

Reviewers: pmenglund
